### PR TITLE
AEROGEAR-2491 - Don't force the use of the containerised apb tools in Makefile command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build_and_push: apb_build docker_push apb_push
 
 .PHONY: apb_build
 apb_build:
-	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest prepare
+	apb prepare
 	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
 
 .PHONY: docker_push
@@ -17,7 +17,7 @@ docker_push:
 
 .PHONY: apb_push
 apb_push:
-	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest push
+	apb push
 
 .PHONY: minishift_pull
 minishift_pull:

--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@
 The Custom Runtime Connector (CRC) allows an existing custom service to be exposed to a mobile application.
 
 Usage information is [here](docs/provision.adoc)
+
+## Local Development
+
+### Requirements
+
+- OpenShift Origin [development environment](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/getting_started.md#development-environment) for APB development.
+- Install [apb tool](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md)
+
+### Process
+
+Upload the APB to the local openshift registry (Runs prepare,build,push and relist) [more info](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#push)
+```bash
+apb push
+```
+
+For more information on APB development and apb command line options, check [ansible-playbook-bundle documentation](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs).


### PR DESCRIPTION
Don't force the use of the containerised apb tools in Makefile commands, apb should be installed locally using one of the recommended approaches https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#installing-the-apb-tool